### PR TITLE
add azcli into Dockerfile, run Dockerfile as non-root user by adding …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TERRAFORM_VERSION ?= 0.12.24
 ANSIBLE_VERSION ?= 2.9.6
 AWSCLI_VERSION ?= 1.18.46
+AZCLI_VERSION ?= 2.5.1
 
 REGISTRY_URL ?= registry.hub.docker.com
 IMAGE_NAME = ci-runner
@@ -16,6 +17,7 @@ build:
 		--build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
 		--build-arg ANSIBLE_VERSION=${ANSIBLE_VERSION} \
 		--build-arg AWSCLI_VERSION=${AWSCLI_VERSION} \
+		--build-arg AZCLI_VERSION=${AZCLI_VERSION} \
 		-t build/$(IMAGE_NAME):$(IMAGE_VERSION) . --no-cache --pull
 
 .PHONY: trivy

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The `FROM` image version is **pinned** (in the `Dockerfile`) to ensure being abl
 | Name | Description |
 |------|:-------------:|
 | ANSIBLE | 2.9.6 |
-| AWS CLI | 1.18.46 |
 | TERRAFORM | 0.12.24 |
+| AWS CLI | 1.18.46 |
+| AZ CLI | 2.5.1 |
 
 # Container security
 
@@ -34,9 +35,4 @@ Tag the repo, the CI will do the rest
 ```
 git tag 1.0.0
 git push --tags
-```
-
-The image name is as follow:
-```
-<my-org>/<my-repo>/<my-img>:<tag_with_ref>
 ```


### PR DESCRIPTION
- add az cli 2.5.1 as default version
- add ci default user for running container as non-root user
- update related documentation